### PR TITLE
Make all Expression sockets yellow

### DIFF
--- a/Scenes/Editor.tscn
+++ b/Scenes/Editor.tscn
@@ -207,6 +207,7 @@ anchor_bottom = 1.0
 custom_styles/panel = SubResource( 1 )
 
 [node name="Modals" type="Control" parent="Mount"]
+editor/display_folded = true
 margin_left = 10.0
 margin_top = 10.0
 margin_right = 1014.0
@@ -381,6 +382,7 @@ columns = 3
 script = ExtResource( 3 )
 
 [node name="File" type="ToolButton" parent="Mount/MainWindow/MenuBar/Menus"]
+editor/display_folded = true
 margin_right = 35.0
 margin_bottom = 22.0
 text = "File"
@@ -586,6 +588,7 @@ text = "CTRL-Q"
 align = 2
 
 [node name="Edit" type="ToolButton" parent="Mount/MainWindow/MenuBar/Menus"]
+editor/display_folded = true
 margin_left = 39.0
 margin_right = 75.0
 margin_bottom = 22.0
@@ -678,6 +681,7 @@ text = "CTRL-Y"
 align = 2
 
 [node name="Help" type="ToolButton" parent="Mount/MainWindow/MenuBar/Menus"]
+editor/display_folded = true
 margin_left = 79.0
 margin_right = 121.0
 margin_bottom = 22.0

--- a/Scenes/Nodes/Condition.tscn
+++ b/Scenes/Nodes/Condition.tscn
@@ -36,7 +36,7 @@ slot/1/right_type = 0
 slot/1/right_color = Color( 1, 1, 1, 1 )
 slot/2/left_enabled = true
 slot/2/left_type = 1
-slot/2/left_color = Color( 1, 1, 1, 1 )
+slot/2/left_color = Color( 0.901961, 0.85098, 0.0745098, 1 )
 slot/2/right_enabled = true
 slot/2/right_type = 0
 slot/2/right_color = Color( 1, 1, 1, 1 )
@@ -119,7 +119,6 @@ margin_right = 75.0
 margin_bottom = 14.0
 text = "false"
 align = 2
-
 [connection signal="close_request" from="." to="." method="_on_Node_close_request"]
 [connection signal="dragged" from="." to="." method="_on_Node_dragged"]
 [connection signal="raise_request" from="." to="." method="_on_Node_raise_request"]

--- a/Scenes/Nodes/End.tscn
+++ b/Scenes/Nodes/End.tscn
@@ -5,7 +5,6 @@
 [ext_resource path="res://Scripts/GraphNode.gd" type="Script" id=3]
 
 [sub_resource type="StyleBoxFlat" id=1]
-
 content_margin_left = 5.0
 content_margin_right = 5.0
 content_margin_top = 5.0
@@ -38,7 +37,7 @@ slot/0/right_type = 0
 slot/0/right_color = Color( 1, 1, 1, 1 )
 slot/1/left_enabled = true
 slot/1/left_type = 1
-slot/1/left_color = Color( 1, 1, 1, 1 )
+slot/1/left_color = Color( 0.901961, 0.85098, 0.0745098, 1 )
 slot/1/right_enabled = false
 slot/1/right_type = 0
 slot/1/right_color = Color( 1, 1, 1, 1 )
@@ -60,7 +59,6 @@ margin_right = 199.0
 margin_bottom = 81.0
 custom_styles/normal = SubResource( 1 )
 text = "expression end-cap"
-
 [connection signal="close_request" from="." to="." method="_on_Node_close_request"]
 [connection signal="dragged" from="." to="." method="_on_Node_dragged"]
 [connection signal="raise_request" from="." to="." method="_on_Node_raise_request"]

--- a/Scenes/Nodes/Expression.tscn
+++ b/Scenes/Nodes/Expression.tscn
@@ -29,7 +29,7 @@ slot/0/left_type = 0
 slot/0/left_color = Color( 1, 1, 1, 1 )
 slot/0/right_enabled = true
 slot/0/right_type = 1
-slot/0/right_color = Color( 1, 1, 1, 1 )
+slot/0/right_color = Color( 0.901961, 0.85098, 0.0745098, 1 )
 script = ExtResource( 3 )
 
 [node name="Lines" type="VBoxContainer" parent="."]


### PR DESCRIPTION
This makes all type 1 graph sockets (currently used to represent expressions) yellow, to help distinguish them from the type 0 dialogue sockets.

Since Github won't let me change the branch of a pull request, I had to close #24 and open a new one.